### PR TITLE
Flatten repo: single Astro app at root, remove nested portfolio-site

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,7 +1,5 @@
 // @ts-check
 import { defineConfig } from 'astro/config';
-
-import { defineConfig } from 'astro/config';
 import tailwind from '@astrojs/tailwind';
 import react from '@astrojs/react';
 import mdx from '@astrojs/mdx';


### PR DESCRIPTION
This PR removes the nested `portfolio-site` repository and consolidates the website into a single repository at the root.\n\nKey changes:\n- Remove nested `portfolio-site` (previously tracked as a gitlink/submodule)\n- Deduplicate and fix `astro.config.mjs` import\n- Ensure root builds and runs (npm install + build verified)\n\nBuild status:\n- Local build PASS (Astro static build): 7 pages generated\n\nImpact:\n- Simplifies repo structure (no nested git repo)\n- Dev commands now run from repo root (`npm run dev`, `npm run build`)\n\nFollow-ups (optional):\n- If any unique history from the nested repo is needed, we can import via subtree.\n\nPlease review and merge.,